### PR TITLE
refactor: use reusable workflow & remove justfile

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,16 +1,15 @@
-name: Whiskers Check
+name: whiskers
+
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: catppuccin/setup-whiskers@v1
-        with:
-          whiskers-version: 2.5.1
-      - run: |
-          whiskers superfile.tera --check
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: superfile.tera
+    secrets: inherit

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers superfile.tera


### PR DESCRIPTION

We now have a reusable workflow for checking whiskers in CI, which is to be used
across the organisation. Note that whiskers will soon start to recommend `^` in
front of the version.

We have also made the decision to remove justfiles from repositories where the
build command is trivial.
